### PR TITLE
lucide-react 패키지 추가

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
         "@tanstack/react-router": "^1.130.1",
         "@tanstack/router-vite-plugin": "^1.130.1",
         "axios": "^1.11.0",
+        "lucide-react": "^0.539.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "zod": "^4.0.10"

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -29,6 +29,9 @@ dependencies:
   axios:
     specifier: ^1.11.0
     version: 1.11.0
+  lucide-react:
+    specifier: ^0.539.0
+    version: 0.539.0(react@19.1.0)
   react:
     specifier: ^19.1.0
     version: 19.1.0
@@ -2466,6 +2469,14 @@ packages:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
     dependencies:
       yallist: 3.1.1
+    dev: false
+
+  /lucide-react@0.539.0(react@19.1.0):
+    resolution: {integrity: sha512-VVISr+VF2krO91FeuCrm1rSOLACQUYVy7NQkzrOty52Y8TlTPcXcMdQFj9bYzBgXbWCiywlwSZ3Z8u6a+6bMlg==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    dependencies:
+      react: 19.1.0
     dev: false
 
   /math-intrinsics@1.1.0:


### PR DESCRIPTION
## 연관 이슈
#13 
## 내용
- lucide-react 패키지 추가
- 라이브러리 선택 기준
  - 필요한 아이콘들을 모두 지원하는가
  - 아이콘 스타일이 서비스와 잘 맞고, 일관적인가
  - React에서 사용하기 편한가 (컴포넌트 형태, 커스터마이징 난이도)
  - 트리셰이킹이 잘 되는가
- 사용 규칙
  - DynamicIcon 사용 지양 - 빌드 중에 모든 아이콘을 가져오기 때문에 빌드 시간에 영향
  - 직접 Icon import
- 주요 사용 icon 목록
  - MapPin: 위치, 브랜드 로고
  - Search: 검색
  - Filter: 필터링
  - Calendar: 날짜, 일정
  - Building2: 기관, 조직
  - Phone: 연락처
  - ExternalLink: 외부 링크
  - TrendingUp: 성장, 통계
  - Users: 사용자, 커뮤니티
  - Clock: 시간, 마감
  - ArrowLeft: 뒤로가기
  - Menu: 메뉴
  - X: 닫기
  - Mail: 이메일
## 알게된 점
- npm의 'unpacked size'와 실제 프로젝트에 영향을 주는 'bundle size'는 다르다.
- **unpacked size** (압축 해제 크기): node_modules 폴더에 설치될 때의 전체 파일 크기.
- **bundle size** (번들 크기): 번들러가 프로젝트를 빌드할 때, 실제 코드에서 사용하는 부분만 추려서 하나 또는 여러 개의 파일로 합친 결과물의 크기. 사용자가 웹사이트를 방문할 때 실제로 다운로드하는 파일의 크기이므로, 웹 성능에 직접적인 영향을 미침
