### PR TITLE
로딩 관련 사용성 개선

### DIFF
--- a/frontend/src/components/ui/card/card.tsx
+++ b/frontend/src/components/ui/card/card.tsx
@@ -8,6 +8,7 @@ type CardVariant = 'basic' | 'surface' | 'accent'
 export interface CardProps extends FlexItemProps, GridItemProps, BoxProps {
   as?: React.ElementType
   variant?: CardVariant
+  radius?: keyof Theme['radius']
   className?: string
   children?: React.ReactNode
 }
@@ -37,24 +38,24 @@ export interface CardProps extends FlexItemProps, GridItemProps, BoxProps {
  * </Card>
  * ```
  */
-export function Card({ as = 'div', variant = 'basic', className, ...rest }: CardProps) {
-  return <Box as={as} css={(theme: Theme) => variantStyles[variant](theme)} className={className} {...rest} />
+export function Card({ as = 'div', variant = 'basic', radius = 'md', className, ...rest }: CardProps) {
+  return <Box as={as} css={(theme: Theme) => variantStyles[variant](theme, radius)} className={className} {...rest} />
 }
 
 const variantStyles = {
-  basic: (theme: Theme) => css`
+  basic: (theme: Theme, radius: keyof Theme['radius']) => css`
     background-color: ${theme.colors.white};
     border: 1px solid ${theme.colors.grey200};
-    border-radius: ${theme.radius.md};
+    border-radius: ${theme.radius[radius]};
   `,
-  surface: (theme: Theme) => css`
+  surface: (theme: Theme, radius: keyof Theme['radius']) => css`
     background-color: ${theme.colors.grey100};
     border: 1px solid ${theme.colors.grey100};
-    border-radius: ${theme.radius.md};
+    border-radius: ${theme.radius[radius]};
   `,
-  accent: (theme: Theme) => css`
+  accent: (theme: Theme, radius: keyof Theme['radius']) => css`
     background-color: ${theme.colors.white};
     border: 2px solid ${theme.colors.green};
-    border-radius: ${theme.radius.md};
+    border-radius: ${theme.radius[radius]};
   `,
 }

--- a/frontend/src/components/ui/skeleton/index.ts
+++ b/frontend/src/components/ui/skeleton/index.ts
@@ -1,0 +1,1 @@
+export { Skeleton, type SkeletonProps } from './skeleton'

--- a/frontend/src/components/ui/skeleton/skeleton.tsx
+++ b/frontend/src/components/ui/skeleton/skeleton.tsx
@@ -1,0 +1,83 @@
+import { css, type Theme, keyframes } from '@emotion/react'
+import { Box, type BoxProps } from '~/components/layout/box'
+
+export interface SkeletonProps extends BoxProps {
+  loading?: boolean
+}
+
+/**
+ * 로딩 상태 표현
+ * @param children - children을 전달하면 skeleton의 크기가 children에 맞게 지정
+ *
+ * @example
+ * ```tsx
+ * // 크기 지정
+ * <Skeleton width="48px" height="48px" />
+ *
+ * // 컴포넌트와 함께 사용
+ * <Skeleton>
+ *   <Button>Click me</Button>
+ * </Skeleton>
+ *
+ * // 텍스트와 함께 사용
+ * <Text>
+ *   <Skeleton>Lorem ipsum dolor sit amet.</Skeleton>
+ * </Text>
+ * ```
+ */
+export function Skeleton({ children, ...rest }: SkeletonProps) {
+  return (
+    <Box as="span" css={skeletonStyles} {...rest}>
+      {children && <span css={hiddenContentStyles}>{children}</span>}
+    </Box>
+  )
+}
+
+const skeletonPulse = keyframes`
+  0% {
+    opacity: 0.6;
+  }
+  50% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0.6;
+  }
+`
+
+const skeletonStyles = (theme: Theme) => css`
+  display: inline-block;
+  background-color: ${theme.colors.grey200};
+  border-radius: ${theme.radius.sm};
+  animation: ${skeletonPulse} 2s ease-in-out infinite;
+
+  &:empty {
+    min-height: 1em;
+    min-width: 4em;
+  }
+
+  * {
+    pointer-events: none;
+    user-select: none;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+  }
+
+  button,
+  input,
+  textarea,
+  select,
+  a,
+  [tabindex] {
+    pointer-events: none !important;
+    opacity: 0.5;
+  }
+`
+
+const hiddenContentStyles = css`
+  visibility: hidden;
+  opacity: 0;
+  pointer-events: none;
+  user-select: none;
+`

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -12,7 +12,13 @@ import { theme } from './styles/theme'
 
 const queryClient = new QueryClient()
 
-const router = createRouter({ routeTree, context: { queryClient }, defaultPendingMs: 100, defaultPendingMinMs: 300 })
+const router = createRouter({
+  routeTree,
+  context: { queryClient },
+  defaultPendingMs: 100,
+  defaultPendingMinMs: 300,
+  scrollRestoration: true,
+})
 
 declare module '@tanstack/react-router' {
   interface Register {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -12,7 +12,7 @@ import { theme } from './styles/theme'
 
 const queryClient = new QueryClient()
 
-const router = createRouter({ routeTree, context: { queryClient } })
+const router = createRouter({ routeTree, context: { queryClient }, defaultPendingMs: 100, defaultPendingMinMs: 300 })
 
 declare module '@tanstack/react-router' {
   interface Register {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,16 +1,18 @@
 import { StrictMode } from 'react'
 import ReactDOM from 'react-dom/client'
+
 import { RouterProvider, createRouter } from '@tanstack/react-router'
-import { QueryClientProvider } from '@tanstack/react-query'
+import { QueryClientProvider, QueryClient } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
-import './styles/global.css'
-
-import { routeTree } from './routeTree.gen'
 import { ThemeProvider } from '@emotion/react'
-import { theme } from './styles/theme'
-import { queryClient } from './queries/query-client'
 
-const router = createRouter({ routeTree })
+import './styles/global.css'
+import { routeTree } from './routeTree.gen'
+import { theme } from './styles/theme'
+
+const queryClient = new QueryClient()
+
+const router = createRouter({ routeTree, context: { queryClient } })
 
 declare module '@tanstack/react-router' {
   interface Register {

--- a/frontend/src/queries/query-client.ts
+++ b/frontend/src/queries/query-client.ts
@@ -1,3 +1,0 @@
-import { QueryClient } from '@tanstack/react-query'
-
-export const queryClient = new QueryClient()

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -1,11 +1,14 @@
-import { createRootRoute, Outlet } from '@tanstack/react-router'
+import { createRootRouteWithContext, Outlet } from '@tanstack/react-router'
 import { TanStackRouterDevtools } from '@tanstack/react-router-devtools'
 import { Header } from '~/components/ui/header'
 import { Footer } from '~/components/ui/footer'
 import { Box } from '~/components/layout/box'
 import { Container } from '~/components/layout/container'
+import type { QueryClient } from '@tanstack/react-query'
 
-export const Route = createRootRoute({
+export const Route = createRootRouteWithContext<{
+  queryClient: QueryClient
+}>()({
   component: () => (
     <>
       <Header />

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -5,20 +5,21 @@ import { Footer } from '~/components/ui/footer'
 import { Box } from '~/components/layout/box'
 import { Container } from '~/components/layout/container'
 import type { QueryClient } from '@tanstack/react-query'
+import { Flex } from '~/components/layout/flex'
 
 export const Route = createRootRouteWithContext<{
   queryClient: QueryClient
 }>()({
   component: () => (
-    <>
+    <Flex direction="column" minHeight="100dvh" justify="between">
       <Header />
-      <Box as="main" width="100%" py="lg">
+      <Box as="main" width="100%" flexGrow="1" py="lg">
         <Container>
           <Outlet />
         </Container>
       </Box>
       <Footer />
       <TanStackRouterDevtools />
-    </>
+    </Flex>
   ),
 })

--- a/frontend/src/routes/notices/$id/index.tsx
+++ b/frontend/src/routes/notices/$id/index.tsx
@@ -3,7 +3,6 @@ import { createFileRoute } from '@tanstack/react-router'
 import { Flex } from '~/components/layout/flex'
 import { Heading } from '~/components/typo/heading'
 import { getNoticeDetailQueryOptions } from '~/queries/notices/notices.query'
-import { queryClient } from '~/queries/query-client'
 import { NOTICE_CATEGORY_OPTIONS } from '../-constants/notice-category-options'
 import { Text } from '~/components/typo/text'
 import { Tag } from '~/components/ui/tag'
@@ -18,8 +17,8 @@ import { Separated } from '~/components/kits/separated'
 
 export const Route = createFileRoute('/notices/$id/')({
   component: () => <NoticeDetail />,
-  loader: ({ params: { id } }) => {
-    return queryClient.ensureQueryData(getNoticeDetailQueryOptions(id))
+  loader: ({ params: { id }, context }) => {
+    return context.queryClient.ensureQueryData(getNoticeDetailQueryOptions(id))
   },
 })
 

--- a/frontend/src/routes/notices/-components/list/index.ts
+++ b/frontend/src/routes/notices/-components/list/index.ts
@@ -1,1 +1,2 @@
 export { NoticeResultsSection } from './notice-results-section'
+export { NoticeResultsSkeleton } from './notice-results-skeleton'

--- a/frontend/src/routes/notices/-components/list/notice-card-skeleton.tsx
+++ b/frontend/src/routes/notices/-components/list/notice-card-skeleton.tsx
@@ -1,0 +1,32 @@
+import { Card } from '~/components/ui/card'
+import { Flex } from '~/components/layout/flex'
+import { Button } from '~/components/ui/button'
+
+import { Dot } from '~/components/ui/dot'
+import { Skeleton } from '~/components/ui/skeleton'
+
+export function NoticeCardSkeleton() {
+  return (
+    <Card variant="basic" as="li" p="xl" minHeight="280px">
+      <Flex direction="column" justify="between" height="100%">
+        <Flex align="center" gap="sm">
+          <Dot color="grey500" size="md" />
+          <Skeleton>lorem</Skeleton>
+        </Flex>
+
+        <Skeleton height="20px">lorem ipsum dolor sit amet.</Skeleton>
+
+        <Skeleton>
+          lorem ipsum dolor sit amet.lorem ipsum dolor sit amet.lorem ipsum dolor sit amet.lorem ipsum dolor sit amet.
+        </Skeleton>
+
+        <Skeleton>lorem ipsum dolor sit amet.</Skeleton>
+        <Skeleton>lorem ipsum dolor sit amet.</Skeleton>
+
+        <Skeleton width="100px">
+          <Button size="sm">lorem</Button>
+        </Skeleton>
+      </Flex>
+    </Card>
+  )
+}

--- a/frontend/src/routes/notices/-components/list/notice-results-empty.tsx
+++ b/frontend/src/routes/notices/-components/list/notice-results-empty.tsx
@@ -1,0 +1,23 @@
+import { TextSearch } from 'lucide-react'
+import { Box } from '~/components/layout/box'
+import { Flex } from '~/components/layout/flex'
+import { Text } from '~/components/typo/text'
+import { Card } from '~/components/ui/card'
+
+export function NoticeResultsEmpty() {
+  return (
+    <Box as="section" py="xl">
+      <Text>관련 공고</Text>
+      <Text as="span" color="grey500">
+        (0개)
+      </Text>
+      <Flex direction="column" align="center" justify="center" gap="lg">
+        <Card variant="surface" p="md" radius="full">
+          <TextSearch size={48} />
+        </Card>
+        <Text>조건에 맞는 결과가 없습니다.</Text>
+        <Text>조건을 변경해보세요.</Text>
+      </Flex>
+    </Box>
+  )
+}

--- a/frontend/src/routes/notices/-components/list/notice-results-section.tsx
+++ b/frontend/src/routes/notices/-components/list/notice-results-section.tsx
@@ -8,14 +8,15 @@ import { getNoticesQueryOptions } from '~/queries/notices/notices.query'
 import { NoticeCard } from './notice-card'
 import { Pagination } from '~/components/ui/pagination'
 import { useNavigate } from '@tanstack/react-router'
+import { NoticeResultsEmpty } from './notice-results-empty'
 
 export function NoticeResultsSection() {
   const search = Route.useSearch()
-  const navigate = useNavigate({ from: Route.fullPath })
   const {
     data: { data: notices, policyInfo, pagination },
   } = useSuspenseQuery(getNoticesQueryOptions(search))
 
+  const navigate = useNavigate({ from: Route.fullPath })
   const onPageChange = (page: number) => {
     navigate({
       search: (prev) => ({
@@ -25,13 +26,18 @@ export function NoticeResultsSection() {
     })
   }
 
+  const isEmpty = notices.length === 0
+  if (isEmpty) {
+    return <NoticeResultsEmpty />
+  }
+
   return (
     <Box as="section" py="xl">
       <Text>{policyInfo?.title ? `${policyInfo.title} 관련` : '전체'} 공고 </Text>
       <Text as="span" color="grey500">
         ({pagination.totalCount}개)
       </Text>
-      <Grid as="ul" templateColumns="repeat(auto-fit, minmax(300px, 1fr))" gap="lg" mt="lg">
+      <Grid as="ul" templateColumns="repeat(auto-fit, minmax(300px, 1fr))" gap="lg" my="lg">
         {notices.map((notice) => (
           <NoticeCard key={notice.id} notice={notice} />
         ))}

--- a/frontend/src/routes/notices/-components/list/notice-results-skeleton.tsx
+++ b/frontend/src/routes/notices/-components/list/notice-results-skeleton.tsx
@@ -1,0 +1,21 @@
+import { Text } from '~/components/typo/text'
+
+import { Box } from '~/components/layout/box'
+import { Grid } from '~/components/layout/grid'
+import { map, pipe, range, toArray } from '@fxts/core'
+import { NoticeCardSkeleton } from './notice-card-skeleton'
+
+export function NoticeResultsSkeleton() {
+  return (
+    <Box as="section" py="xl">
+      <Text>공고</Text>
+      <Grid as="ul" templateColumns="repeat(auto-fit, minmax(300px, 1fr))" gap="lg" mt="lg">
+        {pipe(
+          range(12),
+          map((count) => <NoticeCardSkeleton key={count} />),
+          toArray
+        )}
+      </Grid>
+    </Box>
+  )
+}

--- a/frontend/src/routes/notices/index.tsx
+++ b/frontend/src/routes/notices/index.tsx
@@ -2,9 +2,11 @@ import { createFileRoute } from '@tanstack/react-router'
 import { NoticesSearchSchema } from '~/queries/notices/notices.type'
 import { NoticeResultsSection } from './-components/list'
 import { Suspense } from 'react'
+import { getNoticesQueryOptions } from '~/queries/notices/notices.query'
 
 export const Route = createFileRoute('/notices/')({
   validateSearch: NoticesSearchSchema,
+  loader: ({ context }) => context.queryClient.ensureQueryData(getNoticesQueryOptions()),
   component: () => <Notices />,
 })
 

--- a/frontend/src/routes/notices/index.tsx
+++ b/frontend/src/routes/notices/index.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { NoticesSearchSchema } from '~/queries/notices/notices.type'
-import { NoticeResultsSection } from './-components/list'
+import { NoticeResultsSection, NoticeResultsSkeleton } from './-components/list'
 import { Suspense } from 'react'
 import { getNoticesQueryOptions } from '~/queries/notices/notices.query'
 
@@ -12,7 +12,7 @@ export const Route = createFileRoute('/notices/')({
 
 function Notices() {
   return (
-    <Suspense fallback={<div>Loading...</div>}>
+    <Suspense fallback={<NoticeResultsSkeleton />}>
       <NoticeResultsSection />
     </Suspense>
   )

--- a/frontend/src/routes/policies/-components/list/empty-result.tsx
+++ b/frontend/src/routes/policies/-components/list/empty-result.tsx
@@ -1,0 +1,25 @@
+import { TextSearch } from 'lucide-react'
+import { Box } from '~/components/layout/box'
+import { Flex } from '~/components/layout/flex'
+import { Route } from '../..'
+import { Text } from '~/components/typo/text'
+import { Card } from '~/components/ui/card'
+
+export function EmptyResult() {
+  const search = Route.useSearch()
+  return (
+    <Box as="section" py="xl">
+      <Text>{search.category ?? '전체'} 정책 </Text>
+      <Text as="span" color="grey500">
+        (0개)
+      </Text>
+      <Flex direction="column" align="center" justify="center" gap="lg">
+        <Card variant="surface" p="md" radius="full">
+          <TextSearch size={48} />
+        </Card>
+        <Text>조건에 맞는 결과가 없습니다.</Text>
+        <Text>다른 키워드로 검색하거나 조건을 변경해보세요</Text>
+      </Flex>
+    </Box>
+  )
+}

--- a/frontend/src/routes/policies/-components/list/index.ts
+++ b/frontend/src/routes/policies/-components/list/index.ts
@@ -1,1 +1,2 @@
 export { PolicyResultsSection } from './policy-results-section'
+export { PolicyResultsSkeleton } from './policy-results-skeleton'

--- a/frontend/src/routes/policies/-components/list/policy-card-skeleton.tsx
+++ b/frontend/src/routes/policies/-components/list/policy-card-skeleton.tsx
@@ -1,0 +1,31 @@
+import { Card } from '~/components/ui/card'
+import { Flex } from '~/components/layout/flex'
+import { Dot } from '~/components/ui/dot'
+import { Button } from '~/components/ui/button'
+import { Skeleton } from '~/components/ui/skeleton'
+
+export function PolicyCardSkeleton() {
+  return (
+    <Card variant="surface" as="li" p="xl" minHeight="250px">
+      <Flex direction="column" justify="between" height="100%">
+        <Flex align="center" gap="sm">
+          <Dot color="grey500" size="md" />
+          <Skeleton>lorem</Skeleton>
+        </Flex>
+        <Skeleton height="20px">lorem ipsum dolor.</Skeleton>
+        <Skeleton>
+          lorem ipsum dolor sit amet. lorem ipsum dolor sit amet. lorem ipsum dolor sit amet. lorem ipsum dolor sit
+          amet.
+        </Skeleton>
+        <Flex gap="sm">
+          <Skeleton>
+            <Button size="sm">lorem ipsum</Button>
+          </Skeleton>
+          <Skeleton>
+            <Button size="sm">lorem ipsum</Button>
+          </Skeleton>
+        </Flex>
+      </Flex>
+    </Card>
+  )
+}

--- a/frontend/src/routes/policies/-components/list/policy-results-empty.tsx
+++ b/frontend/src/routes/policies/-components/list/policy-results-empty.tsx
@@ -5,7 +5,7 @@ import { Route } from '../..'
 import { Text } from '~/components/typo/text'
 import { Card } from '~/components/ui/card'
 
-export function EmptyResult() {
+export function PolicyResultsEmpty() {
   const search = Route.useSearch()
   return (
     <Box as="section" py="xl">

--- a/frontend/src/routes/policies/-components/list/policy-results-section.tsx
+++ b/frontend/src/routes/policies/-components/list/policy-results-section.tsx
@@ -7,7 +7,7 @@ import { Grid } from '~/components/layout/grid'
 import { PolicyCard } from './policy-card'
 
 import { filter, pipe, toArray, isUndefined, unless, some, map } from '@fxts/core'
-import { EmptyResult } from './empty-result'
+import { PolicyResultsEmpty } from './policy-results-empty'
 
 export function PolicyResultsSection() {
   const search = Route.useSearch()
@@ -37,7 +37,7 @@ export function PolicyResultsSection() {
 
   const isEmpty = policies.length === 0
   if (isEmpty) {
-    return <EmptyResult />
+    return <PolicyResultsEmpty />
   }
 
   return (

--- a/frontend/src/routes/policies/-components/list/policy-results-section.tsx
+++ b/frontend/src/routes/policies/-components/list/policy-results-section.tsx
@@ -7,6 +7,7 @@ import { Grid } from '~/components/layout/grid'
 import { PolicyCard } from './policy-card'
 
 import { filter, pipe, toArray, isUndefined, unless, some, map } from '@fxts/core'
+import { EmptyResult } from './empty-result'
 
 export function PolicyResultsSection() {
   const search = Route.useSearch()
@@ -33,6 +34,11 @@ export function PolicyResultsSection() {
         toArray
       ),
   })
+
+  const isEmpty = policies.length === 0
+  if (isEmpty) {
+    return <EmptyResult />
+  }
 
   return (
     <Box as="section" py="xl">

--- a/frontend/src/routes/policies/-components/list/policy-results-skeleton.tsx
+++ b/frontend/src/routes/policies/-components/list/policy-results-skeleton.tsx
@@ -1,0 +1,23 @@
+import { Text } from '~/components/typo/text'
+
+import { Box } from '~/components/layout/box'
+import { Grid } from '~/components/layout/grid'
+import { map, pipe, range, toArray } from '@fxts/core'
+import { PolicyCardSkeleton } from './policy-card-skeleton'
+import { Route } from '../..'
+
+export function PolicyResultsSkeleton() {
+  const search = Route.useSearch()
+  return (
+    <Box as="section" py="xl">
+      <Text>{search.category ?? '전체'} 정책 </Text>
+      <Grid as="ul" templateColumns="repeat(auto-fit, minmax(300px, 1fr))" gap="lg" mt="lg">
+        {pipe(
+          range(0, 12),
+          map((number) => <PolicyCardSkeleton key={number} />),
+          toArray
+        )}
+      </Grid>
+    </Box>
+  )
+}

--- a/frontend/src/routes/policies/index.tsx
+++ b/frontend/src/routes/policies/index.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 import { getPoliciesQueryOptions } from '~/queries/policies/policies.query'
 import { PoliciesSearchSchema } from './-types/search'
 import { PolicySearchSection } from './-components/search/policy-search-section'
-import { PolicyResultsSection } from './-components/list'
+import { PolicyResultsSection, PolicyResultsSkeleton } from './-components/list'
 import { Suspense } from 'react'
 
 export const Route = createFileRoute('/policies/')({
@@ -15,7 +15,7 @@ function Policies() {
   return (
     <>
       <PolicySearchSection />
-      <Suspense fallback={<div>Loading...</div>}>
+      <Suspense fallback={<PolicyResultsSkeleton />}>
         <PolicyResultsSection />
       </Suspense>
     </>

--- a/frontend/src/routes/policies/index.tsx
+++ b/frontend/src/routes/policies/index.tsx
@@ -1,14 +1,13 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { getPoliciesQueryOptions } from '~/queries/policies/policies.query'
 import { PoliciesSearchSchema } from './-types/search'
-import { queryClient } from '~/queries/query-client'
 import { PolicySearchSection } from './-components/search/policy-search-section'
 import { PolicyResultsSection } from './-components/list'
 import { Suspense } from 'react'
 
 export const Route = createFileRoute('/policies/')({
   validateSearch: PoliciesSearchSchema,
-  loader: () => queryClient.ensureQueryData(getPoliciesQueryOptions()),
+  loader: ({ context }) => context.queryClient.ensureQueryData(getPoliciesQueryOptions()),
   component: () => <Policies />,
 })
 

--- a/supabase/functions/notices/import_map.json
+++ b/supabase/functions/notices/import_map.json
@@ -1,5 +1,5 @@
 {
     "imports": {
-        "https://esm.sh/@supabase/supabase-js@2": "https://esm.sh/@supabase/supabase-js@2"
+        "https://esm.sh/@supabase/supabase-js@2.38.4": "https://esm.sh/@supabase/supabase-js@2.38.4"
     }
 }

--- a/supabase/functions/notices/index.ts
+++ b/supabase/functions/notices/index.ts
@@ -1,4 +1,4 @@
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.38.4";
 
 const corsHeaders = {
     "Access-Control-Allow-Origin": "*",
@@ -315,9 +315,9 @@ async function handleNoticeList(url: URL) {
                 }
             );
         }
-
+        console.log("totalCountData", totalCountData);
         totalCount = totalCountData || 0;
-
+        console.log("limit, offset", limit, offset);
         // 3. 벡터 유사도 검색 (PostgreSQL pgvector 사용)
         // pgvector 타입이므로 벡터를 그대로 전달
         const { data: similarNotices, error: searchError } = await supabaseClient.rpc("search_similar_notices", {
@@ -326,6 +326,7 @@ async function handleNoticeList(url: URL) {
             match_count: limit,
             offset_count: offset,
         });
+        console.log("similarNotices", similarNotices);
 
         if (searchError) {
             console.error("벡터 검색 오류:", searchError);


### PR DESCRIPTION
## 연관 이슈
#33 #51 #23 
## 내용
### 페이지 이동을 할 때 로딩 UI는 표시되지 않고 이동이 지연되는 문제
#23 의 loader의 캐시 워밍 사용 방식이 잘못된 줄 알고 router와 query 공식문서를 읽어봤을 때, prefetch와 ensureQueryData의 차이는 있었지만 내 서비스에서는 ensureQueryData를 적절하게 사용하고 있었다.  
loader에서 await를 하지 않고 return 했기 때문에 loader에서의 data fetching을 기다리느라 지연되는건 아니었다. performance 탭에서도 data fetching으로 인한 지연은 아닌 것을 확인했다.  
그러던 중에 tanstack router devtool에서 router option을 발견했다.
      <img width="204" height="38" alt="image" src="https://github.com/user-attachments/assets/4bfb540a-9d2e-49bf-a95f-99c2482a7557" />
- defaultPendingMs: pending 상태로 처리하기 위한 지연 임계시간(default: 1000ms) (1초 미만은 pending UI를 보여주지 않고 페이지 이동을 지연한다.)
- defaultPendingMinMs: pending 상태로 처리되었을때 pending 상태를 유지할 최소 시간(default: 500ms)  

defaultPendingMs 때문에 최대 1초까지 페이지 이동이 지연되었던 것을 알게되어 0.1초 미만 일때만 페이지 이동을 지연, 로딩 UI는 최소 0.3초 표시하도록 설정하여 문제를 해결했다.
동시에 #33 의 스켈레톤 UI 표시 기준까지 정립할 수 있었다.

### UI
- 스켈레톤 컴포넌트 추가 및 정책 / 공고 로딩 UI 추가
   ```tsx
    // 기본적으로 children에 따라 크기 맞춤. props로 크기 지정 가능
    // 크기 지정
    <Skeleton width="48px" height="48px" />
 
    // 컴포넌트와 함께 사용
    <Skeleton>
      <Button>Click me</Button>
    </Skeleton>
  
    // 텍스트와 함께 사용
    <Skeleton>Lorem ipsum dolor sit amet.</Skeleton>
    ```
    <img width="1248" height="537" alt="image" src="https://github.com/user-attachments/assets/514e3765-2095-46b2-b5fe-ef9a31ccdbf9" />
- 정책 / 공고 검색 결과가 없는 경우 보여줄 UI 추가
    <img width="1241" height="416" alt="image" src="https://github.com/user-attachments/assets/394b5b65-0c45-461d-9cd2-6a97c0f54e85" />


